### PR TITLE
Optional arg CurrentVectorOnly for Prograde, Retrograde and Retroburn

### DIFF
--- a/Commands.cs
+++ b/Commands.cs
@@ -20,9 +20,9 @@ namespace IngameScript
                 { "reload", CommandReload },
                 { "maxthrustoverrideratio", CommandSetThrustRatio }, { "thrustratio", CommandSetThrustRatio },
                 { "cruise", CommandCruise },
-                { "retro", cmd => CommandRetrograde() }, { "retrograde", cmd => CommandRetrograde() },
-                { "retroburn", cmd => CommandRetroburn() },
-                { "prograde", cmd => CommandPrograde() },
+                { "retro", CommandRetrograde }, { "retrograde", CommandRetrograde },
+                { "retroburn", CommandRetroburn },
+                { "prograde", CommandPrograde },
                 { "radialin", _ => CommandRadialIn() },
                 { "radialout", _ => CommandRadialOut() },
                 { "match", cmd => CommandSpeedMatch() }, { "speedmatch", cmd => CommandSpeedMatch() },
@@ -134,34 +134,43 @@ namespace IngameScript
                 SaveConfig();
             }
         }
-
-        private void CommandRetrograde()
+        
+        private void CommandRetrograde(CommandLine cmd)
         {
             AbortNav(false);
             optionalInfo = "";
             NavMode = NavModeEnum.Retrograde;
-            CruiseController = new Retrograde(aimController, controller, gyros);
+            if (cmd.Count >= 2 && ( cmd[1].ToLower() == "currentvectoronly" || cmd[1].ToLower() == "cvo"))
+                useCurrentVectorOnly = true;
+
+            CruiseController = new Retrograde(aimController, controller, gyros, useCurrentVectorOnly);
             config.PersistStateData = $"{NavModeEnum.Retrograde}";
             SaveConfig();
         }
 
-        private void CommandRetroburn()
+        private void CommandRetroburn(CommandLine cmd)
         {
             AbortNav(false);
             optionalInfo = "";
             thrustController.MaxForwardThrustRatio = (float)config.MaxThrustOverrideRatio;
             NavMode = NavModeEnum.Retroburn;
-            CruiseController = new Retroburn(aimController, controller, gyros, thrustController);
+            if (cmd.Count >= 2 && (cmd[1].ToLower() == "currentvectoronly" || cmd[1].ToLower() == "cvo"))
+                useCurrentVectorOnly = true;
+
+            CruiseController = new Retroburn(aimController, controller, gyros, thrustController, useCurrentVectorOnly);
             config.PersistStateData = $"{NavModeEnum.Retroburn}";
             SaveConfig();
         }
 
-        private void CommandPrograde()
+        private void CommandPrograde(CommandLine cmd)
         {
             AbortNav(false);
             optionalInfo = "";
             NavMode = NavModeEnum.Prograde;
-            CruiseController = new Prograde(aimController, controller, gyros);
+            if (cmd.Count >= 2 && (cmd[1].ToLower() == "currentvectoronly" || cmd[1].ToLower() == "cvo"))
+                useCurrentVectorOnly = true;
+
+            CruiseController = new Prograde(aimController, controller, gyros, useCurrentVectorOnly);
             config.PersistStateData = $"{NavModeEnum.Prograde}";
             SaveConfig();
         }

--- a/Instructions.readme
+++ b/Instructions.readme
@@ -54,20 +54,24 @@ Travels to the target gps (plus configured offsets) or specified forward distanc
 (WeaponCore only) Approaches the locked target and comes to a stop just outside its bounding box.
 IMPORTANT: This uses the position of the target at the time of the command. Use at your own risk if the target is moving.
 
-# Retro/Retrograde
+# Prograde <Optional:CurrentVectorOnly|CVO>
+Points the ship in the direction of travel
+
+# Retro/Retrograde <Optional:CurrentVectorOnly|CVO>
 Points the ship in the opposite direction of travel
 
-# Prograde
-Points the ship in the direction of travel
+# Retroburn <Optional:CurrentVectorOnly|CVO>
+Points the ship to retrograde and stops the ship
+
+## Optional argument: CurrentVectorOnly or CVO
+For the above commands will orient to the vector that existed at the start of execution instead of continously updating.
+Useful when orienting is not possible due to heavy subgrids far offset from the center of mass imparting translational velocity when turning with gyros.
 
 # RadialIn
 Orient toward natural gravity
 
 # RadialOut
 Orient away from natural gravity
-
-# Retroburn
-Points the ship to retrograde and stops the ship
 
 # Match
 Matches speed to CURRENT WeaponCore lock, stays on that target even if locked target changes.

--- a/Navigation/Prograde.cs
+++ b/Navigation/Prograde.cs
@@ -23,17 +23,22 @@ namespace IngameScript
     public class Prograde : Orient
     {
         private const double TERMINATE_SPEED = 5;
-
+        readonly bool _useCurrentVectorOnly;
+        Vector3D initVelocity = Vector3D.Zero;
         public override string Name => nameof(Prograde);
 
-        public Prograde(IAimController aimControl, IMyShipController controller, IList<IMyGyro> gyros)
+        public Prograde(IAimController aimControl, IMyShipController controller, IList<IMyGyro> gyros, bool useCurrentVectorOnly)
             : base(aimControl, controller, gyros)
         {
+            this._useCurrentVectorOnly = useCurrentVectorOnly;
         }
 
         public override void Run()
         {
             Vector3D shipVelocity = ShipController.GetShipVelocities().LinearVelocity;
+
+            if (initVelocity == Vector3D.Zero)
+                initVelocity = shipVelocity;
 
             if (shipVelocity.LengthSquared() <= TERMINATE_SPEED * TERMINATE_SPEED)
             {
@@ -41,7 +46,7 @@ namespace IngameScript
                 return;
             }
 
-            Orient(shipVelocity);
+            Orient(_useCurrentVectorOnly ? initVelocity : shipVelocity);
         }
     }
 }

--- a/Navigation/Retroburn.cs
+++ b/Navigation/Retroburn.cs
@@ -24,7 +24,8 @@ namespace IngameScript
     {
         const double ORIENT_SPEED_THRESHOLD = 5; // don't orient under this speed since it can make the ship turn violently
         const float DAMPENER_TOLERANCE = 0.005f;
-
+        readonly bool _useCurrentVectorOnly;
+        Vector3D initVelocity = Vector3D.Zero;
         public override string Name => nameof(Retroburn);
 
         private VariableThrustController thrustController;
@@ -34,10 +35,12 @@ namespace IngameScript
             IAimController aimControl,
             IMyShipController controller,
             List<IMyGyro> gyros,
-            VariableThrustController thrustController)
+            VariableThrustController thrustController,
+            bool useCurrentVectorOnly)
             : base(aimControl, controller, gyros)
         {
             this.thrustController = thrustController;
+            this._useCurrentVectorOnly = useCurrentVectorOnly;
         }
 
         public override void Run()
@@ -49,12 +52,16 @@ namespace IngameScript
             }
 
             Vector3D shipVelocity = ShipController.GetShipVelocities().LinearVelocity;
+
+            if (initVelocity == Vector3D.Zero)
+                initVelocity = shipVelocity;
+
             double velocitySq = shipVelocity.LengthSquared();
 
             Vector3D gravity = ShipController.GetNaturalGravity();
 
             if (velocitySq > ORIENT_SPEED_THRESHOLD * ORIENT_SPEED_THRESHOLD)
-                Orient(-shipVelocity);
+                Orient(_useCurrentVectorOnly ? -initVelocity : -shipVelocity);
             else if (gravity != Vector3D.Zero)
                 Orient(-gravity);
             else

--- a/Navigation/Retrograde.cs
+++ b/Navigation/Retrograde.cs
@@ -23,17 +23,23 @@ namespace IngameScript
     public class Retrograde : Orient
     {
         const double TERMINATE_SPEED = 5;
+        readonly bool _useCurrentVectorOnly;
+        Vector3D initVelocity = Vector3D.Zero;
 
         public override string Name => nameof(Retrograde);
 
-        public Retrograde(IAimController aimControl, IMyShipController controller, IList<IMyGyro> gyros)
+        public Retrograde(IAimController aimControl, IMyShipController controller, IList<IMyGyro> gyros, bool useCurrentVectorOnly)
             : base(aimControl, controller, gyros)
         {
+            this._useCurrentVectorOnly = useCurrentVectorOnly;
         }
 
         public override void Run()
         {
             Vector3D shipVelocity = ShipController.GetShipVelocities().LinearVelocity;
+
+            if (initVelocity == Vector3D.Zero)
+                initVelocity = shipVelocity;
 
             if (shipVelocity.LengthSquared() <= TERMINATE_SPEED * TERMINATE_SPEED)
             {
@@ -41,7 +47,7 @@ namespace IngameScript
                 return;
             }
 
-            Orient(-shipVelocity);
+            Orient(_useCurrentVectorOnly ? -initVelocity : -shipVelocity);
         }
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -115,6 +115,7 @@ const int printInterval = 10;
         };
         private List<IMyGyro> gyros = new List<IMyGyro>();
         private IMyShipController controller;
+        public static bool useCurrentVectorOnly = false; // false by default
 
         private static readonly StringBuilder debug = new StringBuilder();
         private IMyTextSurface debugLcd;
@@ -170,6 +171,8 @@ const int printInterval = 10;
 
             AbortNav(false);
 
+            CommandLine nullArg = new CommandLine("");
+
             try
             {
                 string stateStr = null;
@@ -199,17 +202,17 @@ const int printInterval = 10;
                 }
                 else if (mode == NavModeEnum.Retrograde)
                 {
-                    CommandRetrograde();
+                    CommandRetrograde(nullArg);
                     stateStr = mode.ToString();
                 }
                 else if (mode == NavModeEnum.Retroburn)
                 {
-                    CommandRetroburn();
+                    CommandRetroburn(nullArg);
                     stateStr = mode.ToString();
                 }
                 else if (mode == NavModeEnum.Prograde)
                 {
-                    CommandPrograde();
+                    CommandPrograde(nullArg);
                     stateStr = mode.ToString();
                 }
                 else if (mode == NavModeEnum.Orient)


### PR DESCRIPTION
Optional argument: CurrentVectorOnly or CVO
For the above commands will orient to the vector that existed at the start of execution instead of continuously updating. Useful when orienting is not possible due to heavy subgrids far offset from the center of mass imparting translational velocity when turning with gyros.