### PR TITLE
Orient will not chase runaway velocity vector

### DIFF
--- a/Navigation/Prograde.cs
+++ b/Navigation/Prograde.cs
@@ -23,6 +23,8 @@ namespace IngameScript
     public class Prograde : Orient
     {
         private const double TERMINATE_SPEED = 5;
+        Vector3D initVelocity = Vector3D.Zero;
+        bool _useInitVector = false;
 
         public override string Name => nameof(Prograde);
 
@@ -34,6 +36,10 @@ namespace IngameScript
         public override void Run()
         {
             Vector3D shipVelocity = ShipController.GetShipVelocities().LinearVelocity;
+            if (initVelocity == Vector3D.Zero)
+                initVelocity = shipVelocity;
+            double diff = Math.Round(Vector3D.Dot(shipVelocity.SafeNormalize(), initVelocity.SafeNormalize()), 5);
+            if (diff < 0.9999 && !ShipController.DampenersOverride) _useInitVector = true;
 
             if (shipVelocity.LengthSquared() <= TERMINATE_SPEED * TERMINATE_SPEED)
             {
@@ -41,7 +47,7 @@ namespace IngameScript
                 return;
             }
 
-            Orient(shipVelocity);
+            Orient(_useInitVector ? initVelocity : shipVelocity);
         }
     }
 }

--- a/Navigation/Retroburn.cs
+++ b/Navigation/Retroburn.cs
@@ -24,7 +24,9 @@ namespace IngameScript
     {
         const double ORIENT_SPEED_THRESHOLD = 5; // don't orient under this speed since it can make the ship turn violently
         const float DAMPENER_TOLERANCE = 0.005f;
-
+        Vector3D initVelocity = Vector3D.Zero;
+        bool _useInitVector = false;
+        
         public override string Name => nameof(Retroburn);
 
         private VariableThrustController thrustController;
@@ -49,12 +51,17 @@ namespace IngameScript
             }
 
             Vector3D shipVelocity = ShipController.GetShipVelocities().LinearVelocity;
+            if (initVelocity == Vector3D.Zero)
+                initVelocity = shipVelocity;
+            double diff = Math.Round(Vector3D.Dot(shipVelocity.SafeNormalize(), initVelocity.SafeNormalize()), 5);
+            if (diff < 0.9999) _useInitVector = true;
+
             double velocitySq = shipVelocity.LengthSquared();
 
             Vector3D gravity = ShipController.GetNaturalGravity();
 
             if (velocitySq > ORIENT_SPEED_THRESHOLD * ORIENT_SPEED_THRESHOLD)
-                Orient(-shipVelocity);
+                Orient(_useInitVector ? -initVelocity : -shipVelocity);
             else if (gravity != Vector3D.Zero)
                 Orient(-gravity);
             else
@@ -66,7 +73,7 @@ namespace IngameScript
 
                 const float UPS = 6;
 
-                if (Vector3D.Dot(-shipVelocity.SafeNormalize(), ShipController.WorldMatrix.Forward) > 0.9999 || velocitySq <= ORIENT_SPEED_THRESHOLD * ORIENT_SPEED_THRESHOLD)
+                if (Vector3D.Dot((_useInitVector ? -initVelocity : -shipVelocity).SafeNormalize(), ShipController.WorldMatrix.Forward) > 0.9999 || velocitySq <= ORIENT_SPEED_THRESHOLD * ORIENT_SPEED_THRESHOLD)
                     thrustController.DampenAllDirections(shipVelocity, gravity, gridMass, UPS - 1); // UPS - 1 to smooth the decel
                 else
                     thrustController.ResetThrustOverrides();

--- a/Navigation/Retrograde.cs
+++ b/Navigation/Retrograde.cs
@@ -23,6 +23,8 @@ namespace IngameScript
     public class Retrograde : Orient
     {
         const double TERMINATE_SPEED = 5;
+        Vector3D initVelocity = Vector3D.Zero;
+        bool _useInitVector = false;
 
         public override string Name => nameof(Retrograde);
 
@@ -34,6 +36,10 @@ namespace IngameScript
         public override void Run()
         {
             Vector3D shipVelocity = ShipController.GetShipVelocities().LinearVelocity;
+            if (initVelocity == Vector3D.Zero)
+                initVelocity = shipVelocity;
+            double diff = Math.Round(Vector3D.Dot(shipVelocity.SafeNormalize(), initVelocity.SafeNormalize()), 5);
+            if (diff < 0.9999 && !ShipController.DampenersOverride) _useInitVector = true;        
 
             if (shipVelocity.LengthSquared() <= TERMINATE_SPEED * TERMINATE_SPEED)
             {
@@ -41,7 +47,7 @@ namespace IngameScript
                 return;
             }
 
-            Orient(-shipVelocity);
+            Orient(_useInitVector ? -initVelocity : -shipVelocity);
         }
     }
 }


### PR DESCRIPTION
If velocity vector drifts during turn (and dampeners are off), do not chase updated vector, but rather target the initial vector from the start of execution. Useful when orienting is not possible due to heavy subgrids far offset from the center of mass imparting translational velocity when turning with gyros.